### PR TITLE
NO-JIRA: Downgrades the go versions for spire-server, spire-agents and spire-oidc-discovery-provider builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea
-
-bin
+bin/

--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -12,6 +12,8 @@ ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 ENV GOFLAGS=""
 
+RUN sed -i 's/^go 1\.24/go 1.23/' go.mod
+
 RUN go build -o bin/spiffe-csi-driver -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spiffe-csi-driver/main.go
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4

--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -6,6 +6,11 @@ WORKDIR ${SOURCE_DIR}
 COPY spiffe-spire .
 COPY spiffe-spire/LICENSE /licenses/.
 
+# 1. Clean up .go-version and go.mod to support Go 1.23.6
+RUN echo "1.23.6" > .go-version && \
+    sed -i '/^tool /d' go.mod && \
+    sed -i 's/^go 1\.24\.1$/go 1.23.6/' go.mod
+
 ENV CGO_ENABLED=1
 ENV GOFLAGS=""
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl

--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -7,7 +7,12 @@ WORKDIR ${SOURCE_DIR}
 COPY spiffe-spire .
 COPY spiffe-spire/LICENSE /licenses/.
 
-# 3. Build the entire package (not just main.go)
+# 1. Clean up .go-version and go.mod to support Go 1.23.6
+RUN echo "1.23.6" > .go-version && \
+    sed -i '/^tool /d' go.mod && \
+    sed -i 's/^go 1\.24\.1$/go 1.23.6/' go.mod
+
+# 2. Build the binary
 ENV CGO_ENABLED=1
 ENV GOFLAGS=""
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
@@ -15,6 +20,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 
 RUN go build -o bin/oidc-discovery-provider -ldflags '-w -s' -tags ${GO_BUILD_TAGS} ./support/oidc-discovery-provider
 
+# Stage 2: Minimal runtime image
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ARG RELEASE_VERSION

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -20,6 +20,12 @@ ENV GOCACHE=/go-cache
 ENV GOMODCACHE=/go-mod
 RUN mkdir -p ${GOTMPDIR} ${GOCACHE} ${GOMODCACHE}
 
+# 1. Clean up .go-version and go.mod to support Go 1.23.6
+RUN echo "1.23.6" > .go-version && \
+    sed -i '/^tool /d' go.mod && \
+    sed -i 's/^go 1\.24\.1$/go 1.23.6/' go.mod
+
+
 # Build the binary and clean up Go build artifacts to free up space
 RUN go build -o bin/spire-server -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spire-server/main.go \
     && go clean -cache -modcache -i -r \

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ outside the main code repository for better management.
 - [spiffe-spire](https://github.com/openshift/spiffe-spire)
 - [spiffe-spire-controller-manager](https://github.com/openshift/spiffe-spire-controller-manager)
 - [spiffe-spiffe-csi](https://github.com/openshift/spiffe-spiffe-csi)
-- [spiffe-spiffe-helper](https://github.com/openshift/spiffe-spiffe-helper)
-- [spiffe-go-spiffe](https://github.com/openshift/spiffe-go-spiffe)
 
 In each release branch the git submodules are configured with equivalent release branch in their respective origin
 repositories. And when switching the parent repository between different branches, the submodule branches will not be


### PR DESCRIPTION
This PR downgrades the Go versions for the spiffe-spire and spiffe-csi container images to match with the go version of `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23` builder for the images.
This PR also cleans the Makefile code.