### PR TITLE
NO-JIRA: Fixes the spire server and spire agent containerfile entry point

### DIFF
--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -28,7 +28,8 @@ ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire"
 COPY --from=builder ${SOURCE_DIR}/bin/spire-agent /spire-agent
 COPY --from=builder /licenses /licenses
 
-USER 65534:65534
+# Run as root user
+USER 0:0
 
 LABEL com.redhat.component="spire-agent-container" \
       name="zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9" \
@@ -45,4 +46,4 @@ LABEL com.redhat.component="spire-agent-container" \
       io.k8s.display-name="SPIRE Agent" \
       io.k8s.description="Container image for the SPIRE Agent component, responsible for workload authentication"
 
-ENTRYPOINT ["/spire-agent"]
+ENTRYPOINT ["/spire-agent", "run"]

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -63,4 +63,4 @@ LABEL com.redhat.component="spire-server-container" \
       io.k8s.description="Container image for the SPIRE Server component, managing trust and identities in SPIFFE/SPIRE systems"
 
 # Entrypoint
-ENTRYPOINT ["/spire-server"]
+ENTRYPOINT ["/spire-server", "run"]


### PR DESCRIPTION
This PR fixes the entry point for the spire server and spire agent builds.
Changes spire agent container file to run as a root user 