### PR TITLE
NO-JIRA: Updates operator bundle config in catalogs

### DIFF
--- a/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
+++ b/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
@@ -1,0 +1,163 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+name: zero-trust-workload-identity-manager.v0.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriverConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgentConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProviderConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServerConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 0.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "zerotrustworkloadidentitymanager-sample"
+            },
+            "spec": null
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: ""
+      createdAt: 2025-06-03T05:27:01
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriverConfig
+        name: spiffecsidriverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgentConfig
+        name: spireagentconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProviderConfig
+        name: spireoidcdiscoveryproviderconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServerConfig
+        name: spireserverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is a Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:90ad7cf82950654c7a69a95dff13c8e7a211260bb284c24d7f6753832c2255fa
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
@@ -1,0 +1,163 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+name: zero-trust-workload-identity-manager.v0.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriverConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgentConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProviderConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServerConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 0.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "zerotrustworkloadidentitymanager-sample"
+            },
+            "spec": null
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: ""
+      createdAt: 2025-06-03T05:27:01
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriverConfig
+        name: spiffecsidriverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgentConfig
+        name: spireagentconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProviderConfig
+        name: spireoidcdiscoveryproviderconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServerConfig
+        name: spireserverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is a Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:90ad7cf82950654c7a69a95dff13c8e7a211260bb284c24d7f6753832c2255fa
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v0.1.0.yaml
@@ -1,0 +1,163 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+name: zero-trust-workload-identity-manager.v0.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriverConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgentConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProviderConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServerConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 0.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "zerotrustworkloadidentitymanager-sample"
+            },
+            "spec": null
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: ""
+      createdAt: 2025-06-03T05:27:01
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "true"
+      features.operators.openshift.io/token-auth-gcp: "true"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriverConfig
+        name: spiffecsidriverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgentConfig
+        name: spireagentconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProviderConfig
+        name: spireoidcdiscoveryproviderconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServerConfig
+        name: spireserverconfigs.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is a Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:90ad7cf82950654c7a69a95dff13c8e7a211260bb284c24d7f6753832c2255fa
+  name: ""
+schema: olm.bundle


### PR DESCRIPTION
PR is for updating the bundle reference in fbc, 4.18 and 4.19 catalogs using `registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:956bf645a3a8eb1e32279a040b7adf0000117530a7a80d58fe13c61dce36134c` image.