### PR TITLE
NO-JIRA: Updated the ZTWIM stage image in image_digest file

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:90ad7cf82950654c7a69a95dff13c8e7a211260bb284c24d7f6753832c2255fa"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:319d40a2a45a546348337ecef7e1b15523bb5d63d71db42039b7fe9db274d878"
 SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6b41e90018d9d2b56af60eff7547c9872dbe1e92f2521d04920450f49147bdc1"
 SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:a3688e555d262ea4866db511d0d03ef2849de54c3a6e32053b211b55cd5ab684"
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:9f914fc47a4159f04514c9e9a1938aff618b3b8be57023402f611ed5a3489ed5"


### PR DESCRIPTION
This PR updated the ZTWIM stage image in the image_digest.conf file to update the image in the bundle.