### PR TITLE
NO-JIRA: updates the base image for 4.18 catalog

### DIFF
--- a/catalogs/v4.18/Containerfile
+++ b/catalogs/v4.18/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
This PR updates the base image for the 4.18 catalog containerfile