### PR TITLE
NO-JIRA: Enables the CGO for the spiffe-helper and controller manager

### DIFF
--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -7,7 +7,7 @@ WORKDIR ${SOURCE_DIR}
 COPY spiffe-spiffe-helper .
 COPY spiffe-spiffe-helper/LICENSE /licenses/.
 
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
 ENV GOFLAGS=""

--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -7,7 +7,7 @@ WORKDIR ${SOURCE_DIR}
 COPY spiffe-spire-controller-manager .
 COPY spiffe-spire-controller-manager/LICENSE /licenses/.
 
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 ENV GO_BUILD_TAGS=strictfipsruntime,openssl
 ENV GOEXPERIMENT=strictfipsruntime
 ENV GOFLAGS=""


### PR DESCRIPTION
This PR enables the CGO flag for the spiffe helper and controller manager in order to make images fips conplaint