### PR TITLE
NO-JIRA: updates the ZTWIM image sha for bundle

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:9aa7b0a9a240d2930d2dc43f689a8a5019041a2a78e8c7569ccedce15f7d2f5c"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:17f533beea953c0a41b4c0a15a6bfd1f959565361509ec521fa43281a4c08e2a"
 SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6b41e90018d9d2b56af60eff7547c9872dbe1e92f2521d04920450f49147bdc1"
 SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:a3688e555d262ea4866db511d0d03ef2849de54c3a6e32053b211b55cd5ab684"
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:9f914fc47a4159f04514c9e9a1938aff618b3b8be57023402f611ed5a3489ed5"


### PR DESCRIPTION
This PR updates the ZTWIM with the latest operator image with changes under https://github.com/openshift/zero-trust-workload-identity-manager/pull/21 