### PR TITLE
Declare CPE ids for each image

### DIFF
--- a/.tekton/spiffe-csi-driver-0-2-7-pull-request.yaml
+++ b/.tekton/spiffe-csi-driver-0-2-7-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.7
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-csi-driver-0-2-7-push.yaml
+++ b/.tekton/spiffe-csi-driver-0-2-7-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.7
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-helper-0-10-1-pull-request.yaml
+++ b/.tekton/spiffe-helper-0-10-1-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.10.1
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-helper-0-10-1-push.yaml
+++ b/.tekton/spiffe-helper-0-10-1-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.10.1
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-agent-1-12-4-pull-request.yaml
+++ b/.tekton/spiffe-spire-agent-1-12-4-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-agent-1-12-4-push.yaml
+++ b/.tekton/spiffe-spire-agent-1-12-4-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-controller-manager-0-6-2-pull-request.yaml
+++ b/.tekton/spiffe-spire-controller-manager-0-6-2-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.6.2
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-controller-manager-0-6-2-push.yaml
+++ b/.tekton/spiffe-spire-controller-manager-0-6-2-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.6.2
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-oidc-discovery-provider-1-12-4-pull-request.yaml
+++ b/.tekton/spiffe-spire-oidc-discovery-provider-1-12-4-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-oidc-discovery-provider-1-12-4-push.yaml
+++ b/.tekton/spiffe-spire-oidc-discovery-provider-1-12-4-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-server-1-12-4-pull-request.yaml
+++ b/.tekton/spiffe-spire-server-1-12-4-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/spiffe-spire-server-1-12-4-push.yaml
+++ b/.tekton/spiffe-spire-server-1-12-4-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v1.12.4
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/zero-trust-workload-identity-manager-0-2-pull-request.yaml
+++ b/.tekton/zero-trust-workload-identity-manager-0-2-pull-request.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.0
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/zero-trust-workload-identity-manager-0-2-push.yaml
+++ b/.tekton/zero-trust-workload-identity-manager-0-2-push.yaml
@@ -32,6 +32,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.0
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/zero-trust-workload-identity-manager-bundle-0-2-pull-request.yaml
+++ b/.tekton/zero-trust-workload-identity-manager-bundle-0-2-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.0
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/.tekton/zero-trust-workload-identity-manager-bundle-0-2-push.yaml
+++ b/.tekton/zero-trust-workload-identity-manager-bundle-0-2-push.yaml
@@ -33,6 +33,7 @@ spec:
   - name: build-args
     value:
       - RELEASE_VERSION=v0.2.0
+      - CPE=cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9
       - COMMIT_SHA={{revision}}
       - SOURCE_URL={{source_url}}
   - name: prefetch-input

--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -19,6 +19,8 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the spiffe-csi source code used in the build.
 ARG RELEASE_VERSION
+## CPE id identifying the product release stream
+ARG CPE
 ## Commit hash that considered for the image build.
 ARG COMMIT_SHA
 ## github URL of the spiffe-spiffe-csi source repository.
@@ -38,6 +40,7 @@ LABEL com.redhat.component="spiffe-csi-driver-container" \
       description="SPIFFE CSI Driver for securely provisioning workload identities in openshift using CSI" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       io.openshift.expose-services="" \
       io.openshift.tags="csi,security,identity,spiffe,spire" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \

--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -21,6 +21,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 # Konflux build metadata
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spiffe-helper"
@@ -33,6 +34,7 @@ USER 65534:65534
 LABEL name="zero-trust-workload-identity-manager/spiffe-helper-rhel9" \
       version="${RELEASE_VERSION}" \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       summary="SPIFFE Helper utility for SPIRE integration" \
       description="Helper binary to support SPIFFE/SPIRE workload identity integrations in OpenShift." \
       maintainer="Red Hat, Inc." \

--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -20,6 +20,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 # Konflux build metadata
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire-controller-manager"
@@ -32,6 +33,7 @@ USER 65534:65534
 LABEL name="zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9" \
       version="${RELEASE_VERSION}" \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       summary="SPIFFE-SPIRE Controller Manager for Kubernetes" \
       description="Controller for managing SPIFFE and SPIRE identities in OpenShift clusters." \
       maintainer="Red Hat, Inc." \

--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -17,6 +17,7 @@ RUN go build -o bin/spire-agent -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spir
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire"
@@ -35,6 +36,7 @@ LABEL com.redhat.component="spire-agent-container" \
       description="SPIRE Agent runs on each node and is responsible for issuing SVIDs to workloads via the workload API" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       io.openshift.tags="spire,identity,spiffe,security" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \

--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -19,6 +19,7 @@ RUN go build -o bin/oidc-discovery-provider -ldflags '-w -s' -tags ${GO_BUILD_TA
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire"
@@ -36,6 +37,7 @@ LABEL com.redhat.component="oidc-discovery-provider-container" \
       description="OIDC Discovery Provider allows SPIRE to serve SVIDs via OIDC compliant endpoints" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       io.openshift.tags="spire,identity,oidc,spiffe,security" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -30,6 +30,7 @@ RUN go build -o bin/spire-server -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spi
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire"
@@ -50,6 +51,7 @@ LABEL com.redhat.component="spire-server-container" \
       description="SPIRE Server manages SPIFFE identities and issues SVIDs to workloads via the SPIRE Agent" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       io.openshift.tags="spire,identity,spiffe,security" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \

--- a/Containerfile.zero-trust-workload-identity-manager
+++ b/Containerfile.zero-trust-workload-identity-manager
@@ -13,6 +13,8 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the zero-trust-workload-identity-manager source code used in the build.
 ARG RELEASE_VERSION
+## CPE id identifying the product release stream
+ARG CPE
 ## Commit hash that considered for the image build.
 ARG COMMIT_SHA
 ## github URL of the zero-trust-workload-identity-manager source repository.
@@ -32,6 +34,7 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-container" \
       description="zero-trust-workload-identity-manager-container" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       io.openshift.expose-services="" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \

--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -19,6 +19,7 @@ RUN ./render_templates.sh /manifests /metadata /images_digest.conf
 FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
 
 ARG RELEASE_VERSION
+ARG CPE
 ARG COMMIT_SHA
 ARG SOURCE_URL
 
@@ -30,6 +31,7 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-containe
       distribution-scope="public" \
       release="${RELEASE_VERSION}" \
       version="${RELEASE_VERSION}" \
+      cpe="${CPE}" \
       url="${SOURCE_URL}" \
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \


### PR DESCRIPTION
So that scanners like clair can find the expected cpe id to match with vulnerability statements (VEX).