### PR TITLE
Fix name label for bundle

### DIFF
--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -24,7 +24,7 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-container" \
-      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-bundle" \
+      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle" \
       summary="zero trust identity manager" \
       description="zero trust identity manager" \
       distribution-scope="public" \


### PR DESCRIPTION
It should match the destination repository where this ultimately gets released.