### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for zero-trust-workload-identity-manager-0-2

### DIFF
--- a/Containerfile.zero-trust-workload-identity-manager
+++ b/Containerfile.zero-trust-workload-identity-manager
@@ -38,6 +38,7 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-container" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.openshift.tags="spire,identity,spiffe,security" \
       io.k8s.display-name="openshift-zero-trust-workload-identity-manager" \
-      io.k8s.description="zero-trust-workload-identity-manager-container"
+      io.k8s.description="zero-trust-workload-identity-manager-container" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.2::el9"
 
 ENTRYPOINT ["/usr/bin/zero-trust-workload-identity-manager"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
