### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-server-1-12-4

### DIFF
--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -43,6 +43,7 @@ USER 65534:65534
 
 # Metadata labels
 LABEL com.redhat.component="spire-server-container" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.2::el9" \
       name="zero-trust-workload-identity-manager/spiffe-spire-server-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="SPIRE Server Component" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
