### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for zero-trust-workload-identity-manager-bundle-0-1

### DIFF
--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -24,7 +24,8 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-container" \
-      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-bundle" \
+      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       summary="zero trust identity manager" \
       description="zero trust identity manager" \
       distribution-scope="public" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
