### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-server-1-12

### DIFF
--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -55,6 +55,7 @@ LABEL com.redhat.component="spire-server-container" \
       description="SPIRE Server manages SPIFFE identities and issues SVIDs to workloads via the SPIRE Agent" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       io.openshift.tags="spire,identity,spiffe,security" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
