### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-oidc-discovery-provider-1-12

### DIFF
--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -41,6 +41,7 @@ LABEL com.redhat.component="oidc-discovery-provider-container" \
       description="OIDC Discovery Provider allows SPIRE to serve SVIDs via OIDC compliant endpoints" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       io.openshift.tags="spire,identity,oidc,spiffe,security" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
