### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-controller-manager-0-6

### DIFF
--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -37,6 +37,7 @@ LABEL name="zero-trust-workload-identity-manager/spiffe-spire-controller-manager
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \
       com.redhat.component="spiffe-spire-controller-manager-container" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       io.k8s.display-name="SPIFFE-SPIRE Controller Manager" \
       io.k8s.description="Kubernetes controller for SPIFFE/SPIRE identity management." \
       io.openshift.tags="spiffe,spire,controller,security,identity" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
