### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-agent-1-12

### DIFF
--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -44,6 +44,7 @@ LABEL com.redhat.component="spire-agent-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="SPIRE Agent" \
-      io.k8s.description="Container image for the SPIRE Agent component, responsible for workload authentication"
+      io.k8s.description="Container image for the SPIRE Agent component, responsible for workload authentication" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9"
 
 ENTRYPOINT ["/spire-agent", "run"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
