### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-helper-0-10

### DIFF
--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -38,6 +38,7 @@ LABEL name="zero-trust-workload-identity-manager/spiffe-helper-rhel9" \
       maintainer="Red Hat, Inc." \
       vendor="Red Hat, Inc." \
       com.redhat.component="spiffe-helper-container" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       io.k8s.display-name="SPIFFE Helper" \
       io.k8s.description="Helper binary for workload identity setup using SPIFFE/SPIRE." \
       io.openshift.tags="spiffe,spire,helper,security,identity" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
