### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for spiffe-spire-csi-driver-0-2

### DIFF
--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -40,6 +40,7 @@ LABEL com.redhat.component="spiffe-csi-driver-container" \
       description="SPIFFE CSI Driver for securely provisioning workload identities in openshift using CSI" \
       vendor="Red Hat, Inc." \
       release="${RELEASE_VERSION}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:0.1::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="csi,security,identity,spiffe,spire" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
