### PR TITLE
SPIRE-258: replaces els to ubi images

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "zero-trust-workload-identity-manager"]
 	path = zero-trust-workload-identity-manager
 	url = https://github.com/openshift/zero-trust-workload-identity-manager.git
-	branch = main
+	branch = release-1.0.0
 [submodule "spiffe-spiffe-helper"]
 	path = spiffe-spiffe-helper
 	url = https://github.com/openshift/spiffe-spiffe-helper.git

--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -14,7 +14,7 @@ ENV GOFLAGS=""
 
 RUN go build -o bin/spiffe-csi-driver -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spiffe-csi-driver/main.go
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the spiffe-csi source code used in the build.

--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -14,7 +14,7 @@ ENV GOFLAGS=""
 
 RUN go build -o bin/spiffe-csi-driver -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spiffe-csi-driver/main.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the spiffe-csi source code used in the build.

--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -17,7 +17,7 @@ ENV GOFLAGS=""
 RUN go build -o bin/spiffe-helper -ldflags "-w -s" -tags ${GO_BUILD_TAGS} cmd/spiffe-helper/main.go
 
 # Final runtime image: minimal RHEL 9 image
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 # Konflux build metadata
 ARG RELEASE_VERSION

--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -17,7 +17,7 @@ ENV GOFLAGS=""
 RUN go build -o bin/spiffe-helper -ldflags "-w -s" -tags ${GO_BUILD_TAGS} cmd/spiffe-helper/main.go
 
 # Final runtime image: minimal RHEL 9 image
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 # Konflux build metadata
 ARG RELEASE_VERSION

--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -16,7 +16,7 @@ ENV GOFLAGS=""
 RUN go build -o bin/spire-controller-manager -ldflags "-w -s" -tags ${GO_BUILD_TAGS} cmd/main.go
 
 # Final runtime image: minimal RHEL 9 image
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 # Konflux build metadata
 ARG RELEASE_VERSION

--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -16,7 +16,7 @@ ENV GOFLAGS=""
 RUN go build -o bin/spire-controller-manager -ldflags "-w -s" -tags ${GO_BUILD_TAGS} cmd/main.go
 
 # Final runtime image: minimal RHEL 9 image
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 # Konflux build metadata
 ARG RELEASE_VERSION

--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -14,7 +14,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 
 RUN go build -o bin/spire-agent -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spire-agent/main.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -14,7 +14,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 
 RUN go build -o bin/spire-agent -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spire-agent/main.go
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -16,7 +16,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN go build -o bin/oidc-discovery-provider -ldflags '-w -s' -tags ${GO_BUILD_TAGS} ./support/oidc-discovery-provider
 
 # Stage 2: Minimal runtime image
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -16,7 +16,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN go build -o bin/oidc-discovery-provider -ldflags '-w -s' -tags ${GO_BUILD_TAGS} ./support/oidc-discovery-provider
 
 # Stage 2: Minimal runtime image
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -27,7 +27,7 @@ RUN go build -o bin/spire-server -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spi
     && rm -rf ${GOTMPDIR} ${GOCACHE} ${GOMODCACHE}
 
 # Final minimal image
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -27,7 +27,7 @@ RUN go build -o bin/spire-server -ldflags '-w -s' -tags ${GO_BUILD_TAGS} cmd/spi
     && rm -rf ${GOTMPDIR} ${GOCACHE} ${GOMODCACHE}
 
 # Final minimal image
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.zero-trust-workload-identity-manager
+++ b/Containerfile.zero-trust-workload-identity-manager
@@ -8,7 +8,7 @@ COPY zero-trust-workload-identity-manager/LICENSE /licenses/
 
 RUN make build --warn-undefined-variables
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the zero-trust-workload-identity-manager source code used in the build.

--- a/Containerfile.zero-trust-workload-identity-manager
+++ b/Containerfile.zero-trust-workload-identity-manager
@@ -8,7 +8,7 @@ COPY zero-trust-workload-identity-manager/LICENSE /licenses/
 
 RUN make build --warn-undefined-variables
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 # Values for below ARGs will passed from tekton configs for konflux builds.
 ## Release version of the zero-trust-workload-identity-manager source code used in the build.

--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -16,7 +16,7 @@ COPY tools.go go.mod go.sum /
 RUN go build -o /usr/bin/yq github.com/mikefarah/yq/v4 && chmod +x /usr/bin/yq
 RUN ./render_templates.sh /manifests /metadata /images_digest.conf
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:c7d44146f826037f6873d99da479299b889473492d3c1ab8af86f08af04ec8a0
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA

--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -16,7 +16,7 @@ COPY tools.go go.mod go.sum /
 RUN go build -o /usr/bin/yq github.com/mikefarah/yq/v4 && chmod +x /usr/bin/yq
 RUN ./render_templates.sh /manifests /metadata /images_digest.conf
 
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA


### PR DESCRIPTION
This PR focuses on replacing all components of ZTWIM base images to UBI Minimal images