### PR TITLE
SPIRE-138: Updates the operator image for the new bundle image

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ada72f40b19ba532841fbac2300ce4fbfa75aa51db6c4416c61900cb86b99473"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:a9ebe1ccbd2395957aebe988ed2f63527220b7f2ef7ac7674aeac1ee0aeb047f"
 SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4"
 SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:54865d9de74a500528dcef5c24dfe15c0baee8df662e76459e83bf9921dfce4e"
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d"


### PR DESCRIPTION
PR updates the sha version for the operator image with the latest changes