### PR TITLE
NO-JIRA: Update node driver registrar image and spiffe csi init container imageVersion

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -10,5 +10,5 @@ SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d"
 SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:70f04312f96851a37ec9bfcc605d6a7edb4c87b548621007183b7caa2333816a"
 SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:7ddf330a798dbb112c2f58d2548941100a964db705617680d09969eaa3e07727"
-NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:7d170ba9b3de2e88dc0d0a6b0c13630ca3b23eed96ea5e3c725516046d7c7fc7"
-SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774"
+NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b"
+SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc"


### PR DESCRIPTION
## Update image digests for NODE_DRIVER_REGISTRAR and UBI9 init container

### Description

This PR updates the image digests in `images_digest.conf` to use newer versions of the following images:

| Image | Previous Version | New Version |
|-------|------------------|-------------|
| `ose-csi-node-driver-registrar-rhel9` | v4.18.0 | **v4.20.0** |
| `ubi9` (init container) | 9.6 (release 1749542372) | **9.6** (release 1760340943) |

### Image Details

**NODE_DRIVER_REGISTRAR_IMAGE:**
- Old: `sha256:7d170ba9b3de2e88dc0d0a6b0c13630ca3b23eed96ea5e3c725516046d7c7fc7`
- New: `sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b`
- Version: `v4.20.0-202511250912.p2.g6ce4713.assembly.stream.el9`

**SPIFFE_CSI_INIT_CONTAINER_IMAGE (UBI9):**
- Old: `sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774`
- New: `sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc`
- Version: `9.6-1760340943`

### Why

- Updates `ose-csi-node-driver-registrar` from OpenShift 4.18 to 4.20 to pick up latest bug fixes and security patches
- Updates UBI9 base image to the latest release for security