### PR TITLE
NO-JIRA: Updates the 4.20 and 4.21 catalog with latest bundle image

### DIFF
--- a/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.0.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.0.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:cfd21c981ea1fce408e309b346ce8005e8b0ee73fe5e2461eefaf7ea867f3831
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:ecb4cb37b11baf98669db061d90270c420f78d4a7f62492ed6f76bc39cd90396
 name: zero-trust-workload-identity-manager.v1.0.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -259,7 +259,7 @@ properties:
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
       containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:a2f83e5e9433361b279b9609d4492300fc8e9ed3c0ca737d5805f5b06a0e3777
-      createdAt: 2025-12-09T14:41:25
+      createdAt: 2025-12-16T04:29:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -345,9 +345,9 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.access.redhat.com/ubi9@sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774
+- image: registry.access.redhat.com/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc
   name: spiffe-csi-init-container
-- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:7d170ba9b3de2e88dc0d0a6b0c13630ca3b23eed96ea5e3c725516046d7c7fc7
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b
   name: node-driver-registrar
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d
   name: spiffe-csi-driver
@@ -359,7 +359,7 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:cfd21c981ea1fce408e309b346ce8005e8b0ee73fe5e2461eefaf7ea867f3831
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:ecb4cb37b11baf98669db061d90270c420f78d4a7f62492ed6f76bc39cd90396
   name: ""
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:a2f83e5e9433361b279b9609d4492300fc8e9ed3c0ca737d5805f5b06a0e3777
   name: ""

--- a/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.0.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.0.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:cfd21c981ea1fce408e309b346ce8005e8b0ee73fe5e2461eefaf7ea867f3831
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:ecb4cb37b11baf98669db061d90270c420f78d4a7f62492ed6f76bc39cd90396
 name: zero-trust-workload-identity-manager.v1.0.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -259,7 +259,7 @@ properties:
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
       containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:a2f83e5e9433361b279b9609d4492300fc8e9ed3c0ca737d5805f5b06a0e3777
-      createdAt: 2025-12-09T14:41:25
+      createdAt: 2025-12-16T04:29:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -345,9 +345,9 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.access.redhat.com/ubi9@sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774
+- image: registry.access.redhat.com/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc
   name: spiffe-csi-init-container
-- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:7d170ba9b3de2e88dc0d0a6b0c13630ca3b23eed96ea5e3c725516046d7c7fc7
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b
   name: node-driver-registrar
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d
   name: spiffe-csi-driver
@@ -359,7 +359,7 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:cfd21c981ea1fce408e309b346ce8005e8b0ee73fe5e2461eefaf7ea867f3831
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:ecb4cb37b11baf98669db061d90270c420f78d4a7f62492ed6f76bc39cd90396
   name: ""
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:a2f83e5e9433361b279b9609d4492300fc8e9ed3c0ca737d5805f5b06a0e3777
   name: ""


### PR DESCRIPTION
This PR updates the catalog for 4.20 and 4.21 with the updated bundle image, Spiffe CSI init container, and node driver registrar image update