### PR TITLE
SPIRE-142: Update prod image reference for bundle Image.

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,11 +4,11 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:9d88df06140dfdfd18f9467fb7ecfdb5508a8f559301b6173c9b6490cc22cc37"
-SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4"
-SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:54865d9de74a500528dcef5c24dfe15c0baee8df662e76459e83bf9921dfce4e"
-SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d"
-SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:70f04312f96851a37ec9bfcc605d6a7edb4c87b548621007183b7caa2333816a"
-SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:7ddf330a798dbb112c2f58d2548941100a964db705617680d09969eaa3e07727"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:9d88df06140dfdfd18f9467fb7ecfdb5508a8f559301b6173c9b6490cc22cc37"
+SPIRE_SERVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4"
+SPIRE_AGENT_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:54865d9de74a500528dcef5c24dfe15c0baee8df662e76459e83bf9921dfce4e"
+SPIFFE_CSI_DRIVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d"
+SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:70f04312f96851a37ec9bfcc605d6a7edb4c87b548621007183b7caa2333816a"
+SPIRE_CONTROLLER_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:7ddf330a798dbb112c2f58d2548941100a964db705617680d09969eaa3e07727"
 NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b"
 SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc"


### PR DESCRIPTION
This PR updates the bundle image reference with the prod images.

```
$ docker images --digests  | grep registry.redhat.io
registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9                   v1.0.0    sha256:9d88df06140dfdfd18f9467fb7ecfdb5508a8f559301b6173c9b6490cc22cc37   a9ace99562ae   23 hours ago   292MB
registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9                                     v1.13.3   sha256:54865d9de74a500528dcef5c24dfe15c0baee8df662e76459e83bf9921dfce4e   87989b2527d1   12 days ago    267MB
registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9                        v0.6.3    sha256:7ddf330a798dbb112c2f58d2548941100a964db705617680d09969eaa3e07727   c2901c4d5d21   12 days ago    255MB
registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9                                    v1.13.3   sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4   04dd8c813105   12 days ago    373MB
registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9                   v1.13.3   sha256:70f04312f96851a37ec9bfcc605d6a7edb4c87b548621007183b7caa2333816a   4a7d395f61d7   12 days ago    223MB
registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9                                      v0.2.8    sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d   2387b51a22c4   12 days ago    219MB

```