### PR TITLE
NO-JIRA: Add CPE label to all Containerfiles for release pipeline compliance

### DIFF
--- a/Containerfile.spiffe-spiffe-csi
+++ b/Containerfile.spiffe-spiffe-csi
@@ -44,6 +44,7 @@ LABEL com.redhat.component="spiffe-csi-driver-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="SPIFFE CSI Driver" \
-      io.k8s.description="Container for the SPIFFE CSI Driver, used to mount SPIFFE SVIDs into pods"
+      io.k8s.description="Container for the SPIFFE CSI Driver, used to mount SPIFFE SVIDs into pods" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/spiffe-csi-driver"]

--- a/Containerfile.spiffe-spiffe-helper
+++ b/Containerfile.spiffe-spiffe-helper
@@ -43,6 +43,7 @@ LABEL name="zero-trust-workload-identity-manager/spiffe-helper-rhel9" \
       io.openshift.tags="spiffe,spire,helper,security,identity" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \
-      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}"
+      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/spiffe-helper"]

--- a/Containerfile.spiffe-spire-controller-manager
+++ b/Containerfile.spiffe-spire-controller-manager
@@ -43,6 +43,7 @@ LABEL name="zero-trust-workload-identity-manager/spiffe-spire-controller-manager
       io.openshift.expose-services="" \
       io.openshift.build.commit.id="${COMMIT_SHA}" \
       io.openshift.build.source-location="${SOURCE_URL}" \
-      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}"
+      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/spire-controller-manager"]

--- a/Containerfile.spire-agent
+++ b/Containerfile.spire-agent
@@ -40,6 +40,7 @@ LABEL com.redhat.component="spire-agent-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="SPIRE Agent" \
-      io.k8s.description="Container image for the SPIRE Agent component, responsible for workload authentication"
+      io.k8s.description="Container image for the SPIRE Agent component, responsible for workload authentication" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/spire-agent", "run"]

--- a/Containerfile.spire-oidc-discovery-provider
+++ b/Containerfile.spire-oidc-discovery-provider
@@ -41,6 +41,7 @@ LABEL com.redhat.component="oidc-discovery-provider-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="OIDC Discovery Provider" \
-      io.k8s.description="Container for OIDC Discovery Provider to expose SPIFFE identities via standard OIDC interfaces"
+      io.k8s.description="Container for OIDC Discovery Provider to expose SPIFFE identities via standard OIDC interfaces" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/oidc-discovery-provider"]

--- a/Containerfile.spire-server
+++ b/Containerfile.spire-server
@@ -55,7 +55,8 @@ LABEL com.redhat.component="spire-server-container" \
       io.openshift.build.source-location="${SOURCE_URL}" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.k8s.display-name="SPIRE Server" \
-      io.k8s.description="Container image for the SPIRE Server component, managing trust and identities in SPIFFE/SPIRE systems"
+      io.k8s.description="Container image for the SPIRE Server component, managing trust and identities in SPIFFE/SPIRE systems" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 # Entrypoint
 ENTRYPOINT ["/spire-server", "run"]

--- a/Containerfile.zero-trust-workload-identity-manager
+++ b/Containerfile.zero-trust-workload-identity-manager
@@ -38,6 +38,7 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-container" \
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.openshift.tags="spire,identity,spiffe,security" \
       io.k8s.display-name="openshift-zero-trust-workload-identity-manager" \
-      io.k8s.description="zero-trust-workload-identity-manager-container"
+      io.k8s.description="zero-trust-workload-identity-manager-container" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 ENTRYPOINT ["/usr/bin/zero-trust-workload-identity-manager"]

--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -51,7 +51,8 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-containe
       operators.operatorframework.io.bundle.channels.v1="stable-v1" \
       operators.operatorframework.io.metrics.builder="operator-sdk-v1.25.1" \
       operators.operatorframework.io.metrics.mediatype.v1="metrics+v1" \
-      operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3"
+      operators.operatorframework.io.metrics.project_layout="go.kubebuilder.io/v3" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1 \


### PR DESCRIPTION
## Summary

- Adds `cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.0::el9"` label to all 8 Containerfiles
- Overrides the `cpe:/a:redhat:enterprise_linux:9::appstream` label inherited from the UBI 9 minimal base image
- Fixes the `check-labels` release pipeline failure where the CPE value did not match the required value from the release data file

## Files Changed
- Containerfile.spiffe-spiffe-csi
- Containerfile.spiffe-spiffe-helper
- Containerfile.spiffe-spire-controller-manager
- Containerfile.spire-agent
- Containerfile.spire-oidc-discovery-provider
- Containerfile.spire-server
- Containerfile.zero-trust-workload-identity-manager
- Containerfile.zero-trust-workload-identity-manager.bundle