### PR TITLE
SPIRE-500: Update image digests to stage registry for v1.0.1 release

### DIFF
--- a/Containerfile.zero-trust-workload-identity-manager.bundle
+++ b/Containerfile.zero-trust-workload-identity-manager.bundle
@@ -24,7 +24,7 @@ ARG SOURCE_URL
 
 # Core bundle labels.
 LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-container" \
-      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-bundle" \
+      name="zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle" \
       summary="zero trust identity manager" \
       description="zero trust identity manager" \
       distribution-scope="public" \
@@ -41,7 +41,7 @@ LABEL com.redhat.component="zero-trust-workload-identity-manager-bundle-containe
       io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
       io.openshift.tags="openshift,security,zero-trust-workload-identity-manager" \
-      io.k8s.display-name="openshift-zero-trust-workload-identity-manager-bundle" \
+      io.k8s.display-name="openshift-zero-trust-workload-identity-manager-operator-bundle" \
       io.k8s.description="zero-trust-workload-identity-manager-bundle-container" \
       operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
       operators.operatorframework.io.bundle.manifests.v1=manifests/ \

--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,11 +4,11 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:9d88df06140dfdfd18f9467fb7ecfdb5508a8f559301b6173c9b6490cc22cc37"
-SPIRE_SERVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:6a14fb03c3b7256a405cff52ae0e5c7e66b1fa1a8e3a955d6670123f5534d4e4"
-SPIRE_AGENT_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:54865d9de74a500528dcef5c24dfe15c0baee8df662e76459e83bf9921dfce4e"
-SPIFFE_CSI_DRIVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:5359e8709d1b73386eddef202d59b7c511aa5366ca04f5ee707bbf760977e55d"
-SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:70f04312f96851a37ec9bfcc605d6a7edb4c87b548621007183b7caa2333816a"
-SPIRE_CONTROLLER_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:7ddf330a798dbb112c2f58d2548941100a964db705617680d09969eaa3e07727"
-NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:1c480fa5089a32cf804fc84df7219ca64066cbac2eeb962c4385754132c3873b"
-SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c90ed9e428a4e5f8cc85e88de0ef1e80834700a0354f796d13154e50cd95a2fe"
+SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:1adc34cd1e87024bab6850b2cda63743f42c57ae7c3ae483574760294b1a91a9"
+SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:402eabe171ba8129489ddd12eccea03e475da226fcd230eba5bfdeff3d73dc8e"
+SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:e15e0b3442602833be8e3297cfac1333ce9e45ebc0d9a893f2a758702aff75e1"
+SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:47142dd4fefad52dcd1c749532f7de761bb9d463a9d90349c8987c769f3e3438"
+SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:fcd19d7b5c774ada1c7f9abf3367796ef7a113c4d2e2566ffc3cc0f0be222c4d"
+NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:715fed4adf4280d9a8e92a09cdcc35ed9bb95e623b1d5fc2f1b753981ecf41f4"
+SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:f3b9841ea7615b38fd271cf18ae235d8228d3369036eb175ded171c936808255"


### PR DESCRIPTION
Summary
Switch component image references from `registry.redhat.io` to `registry.stage.redhat.io` for stage validation
Update all image digests to latest versions: ZTWIM v1.0.1, SPIRE server/agent/OIDC v1.13.3, CSI driver v0.2.8, controller manager v0.6.4, node driver registrar v4.20.0, UBI9 9.6
Keep `NODE_DRIVER_REGISTRAR_IMAGE` on `registry.redhat.io` and `SPIFFE_CSI_INIT_CONTAINER_IMAGE` on `registry.access.redhat.com`