### PR TITLE
SPIRE-496: Update images_digest.conf to production registry with latest digests

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,11 +4,11 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c90ed9e428a4e5f8cc85e88de0ef1e80834700a0354f796d13154e50cd95a2fe"
-SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:1adc34cd1e87024bab6850b2cda63743f42c57ae7c3ae483574760294b1a91a9"
-SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:402eabe171ba8129489ddd12eccea03e475da226fcd230eba5bfdeff3d73dc8e"
-SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:e15e0b3442602833be8e3297cfac1333ce9e45ebc0d9a893f2a758702aff75e1"
-SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:47142dd4fefad52dcd1c749532f7de761bb9d463a9d90349c8987c769f3e3438"
-SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:fcd19d7b5c774ada1c7f9abf3367796ef7a113c4d2e2566ffc3cc0f0be222c4d"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:d91be0579f6f450e6087821f50fed5daaa11695f0012ac4811f7de233a899125"
+SPIRE_SERVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:43b61f7ebd7878c1e551b2827677943f7f5f14f246a7d3723e22ff78e246b42a"
+SPIRE_AGENT_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:7a5f16d95fa266ba3469ee243c52353d9598d8071bfbddadeadef547f7c3ac01"
+SPIFFE_CSI_DRIVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:8bb983e675402a68533c4af609bc3859c46dc5c4736563a0779ae4ced2899f74"
+SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:03a54fe0917ddb04af1a5feb38097e89e5517a1851f589127b747efa2395faa2"
+SPIRE_CONTROLLER_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:6e8190e3c46b75076a7dc153719b4aec8fe2dd21b75a95d02baeaeaccc7cb50b"
 NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:715fed4adf4280d9a8e92a09cdcc35ed9bb95e623b1d5fc2f1b753981ecf41f4"
 SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:f3b9841ea7615b38fd271cf18ae235d8228d3369036eb175ded171c936808255"


### PR DESCRIPTION
## Summary

- Updates `images_digest.conf` to use production registry (`registry.redhat.io`) instead of staging (`registry.stage.redhat.io`)
- Pulls fresh SHA digests from the production registry for all 6 component images
- All images were built on 2026-05-08 and are the latest available for their respective version tags

## Image Versions

| Component | Version | Build Date |
|-----------|---------|-----------|
| zero-trust-workload-identity-manager | v1.0.1 | 2026-05-08 |
| spire-server | v1.13.3 | 2026-05-08 |
| spire-agent | v1.13.3 | 2026-05-08 |
| spiffe-csi-driver | v0.2.8 | 2026-05-08 |
| spire-oidc-discovery-provider | v1.13.3 | 2026-05-08 |
| spire-controller-manager | v0.6.4 | 2026-05-08 |

## Files Changed
- `images_digest.conf` — registry and digest updates for 6 component images


Made with [Cursor](https://cursor.com)