### PR TITLE
SPIRE-418: Add v1.1.0 stage image digests for release-1.1

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,11 +4,12 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:PLACEHOLDER"
-SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:PLACEHOLDER"
-SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:PLACEHOLDER"
-SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:PLACEHOLDER"
-SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:PLACEHOLDER"
-SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:PLACEHOLDER"
-NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:715fed4adf4280d9a8e92a09cdcc35ed9bb95e623b1d5fc2f1b753981ecf41f4"
-SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:f3b9841ea7615b38fd271cf18ae235d8228d3369036eb175ded171c936808255"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711"
+SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8"
+SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8"
+SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703"
+SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7"
+SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea"
+SPIFFE_HELPER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9@sha256:977148a3e7cfdc64fa98435398cb6dbbfc346c6c2b21f416b8953519e0e92ac4"
+NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232"
+SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319"


### PR DESCRIPTION
## Summary
- Update `images_digest.conf` replacing PLACEHOLDER values with actual stage registry SHA digests for all v1.1.0 component images
- Add new `SPIFFE_HELPER_IMAGE` entry (spiffe-helper-rhel9:v0.11.0)
- Update `NODE_DRIVER_REGISTRAR_IMAGE` and `SPIFFE_CSI_INIT_CONTAINER_IMAGE` digests to latest

## Image Versions

| Component | Version | Source Commit |
|-----------|---------|---------------|
| zero-trust-workload-identity-manager | v1.1.0 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-spire-server | v1.14.7 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-spire-agent | v1.14.7 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-spire-oidc-discovery-provider | v1.14.7 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-spire-controller-manager | v0.6.4 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-csi-driver | v0.2.8 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| spiffe-helper | v0.11.0 | `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` |
| ose-csi-node-driver-registrar | v4.21.0 (latest) | `d29f3f7a4aed4465e7e40e323bd3c0e0d9871e4c` |
| ubi9 | 9.8 (latest) | `a1ff645e4d0b83aad1b77555a562c5807a8af5bf` |

---

## Image Verification Proof

### 1. zero-trust-workload-identity-manager-rhel9:v1.1.0

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9:v1.1.0
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9:v1.1.0...
Getting image source signatures
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying blob sha256:61ab9f9dd6ef38ee0b315ff9840a049b5e1e3894a8cb5284bae2e1e44ffd4026
Copying config sha256:a5b354e812f42c133b062adfdfe26b0c4dc072bcaa2bf957a40d719813cce65e
Writing manifest to image destination
a5b354e812f42c133b062adfdfe26b0c4dc072bcaa2bf957a40d719813cce65e
```
**Digest:** `sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `zero-trust-workload-identity-manager-container`

---

### 2. spiffe-spire-server-rhel9:v1.14.7

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9:v1.14.7
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9:v1.14.7...
Getting image source signatures
Copying blob sha256:3a553f5ede938ae78e5b9254343fa8b50a64d8bd31201cbaa24a6527533a392a
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:923890ed119fef82d2974b523e07fc87048841b775bd0201a6e184b953cd1af3
Writing manifest to image destination
923890ed119fef82d2974b523e07fc87048841b775bd0201a6e184b953cd1af3
```
**Digest:** `sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `spire-server-container`

---

### 3. spiffe-spire-agent-rhel9:v1.14.7

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9:v1.14.7
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9:v1.14.7...
Getting image source signatures
Copying blob sha256:47689749dcf05b749683371119d43eb9962ff9ff18e1a9bdc07c7d1635ef6500
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:cb2a512aef0986305236974e7d8c6bc5051329680423c4773cd3ae4db52e873f
Writing manifest to image destination
cb2a512aef0986305236974e7d8c6bc5051329680423c4773cd3ae4db52e873f
```
**Digest:** `sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `spire-agent-container`

---

### 4. spiffe-spire-oidc-discovery-provider-rhel9:v1.14.7

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9:v1.14.7
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9:v1.14.7...
Getting image source signatures
Copying blob sha256:6b47c8a5e0c5930458feba4336ac46bd0ea315cd8ee15fae76b4fd65eb06ff22
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:f66bc7dc1e6b5028fb2f522724aabe9fa3eca3ca77d14a54dd1aa38e4a8bf33f
Writing manifest to image destination
f66bc7dc1e6b5028fb2f522724aabe9fa3eca3ca77d14a54dd1aa38e4a8bf33f
```
**Digest:** `sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `oidc-discovery-provider-container`

---

### 5. spiffe-spire-controller-manager-rhel9:v0.6.4

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9:v0.6.4
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9:v0.6.4...
Getting image source signatures
Copying blob sha256:72eb80334a3f0c382bc0cc03d910418d39cb345dca28cf53f00ca58606f43ec2
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:e0efb74bb4d59bd82ca546a2d6a951fa17b4039a4c6f2f6db6892d01ec244675
Writing manifest to image destination
e0efb74bb4d59bd82ca546a2d6a951fa17b4039a4c6f2f6db6892d01ec244675
```
**Digest:** `sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `spiffe-spire-controller-manager-container`

---

### 6. spiffe-csi-driver-rhel9:v0.2.8

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9:v0.2.8
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9:v0.2.8...
Getting image source signatures
Copying blob sha256:1cd7978bfe8d5969fff03b4c4c9f944dae356f9036af7fe1b271109bb92adbe8
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:88c20739ec48976874d99d324afb56b2e9fa1ce41a4734e0b52e0f42d9808386
Writing manifest to image destination
88c20739ec48976874d99d324afb56b2e9fa1ce41a4734e0b52e0f42d9808386
```
**Digest:** `sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `spiffe-csi-driver-container`

---

### 7. spiffe-helper-rhel9:v0.11.0 (NEW)

**Pull:**
```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:v0.11.0
Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:v0.11.0...
Getting image source signatures
Copying blob sha256:0ad7083b186221185f3d8151ba6f7d1efc54a762c3cf49159bf7f0cfc0ed313f
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:ef97c2114ac8dcb4d4db564664baeb7042631bd84914767fdd0e1949f6a7c54f
Writing manifest to image destination
ef97c2114ac8dcb4d4db564664baeb7042631bd84914767fdd0e1949f6a7c54f
```
**Digest:** `sha256:977148a3e7cfdc64fa98435398cb6dbbfc346c6c2b21f416b8953519e0e92ac4`
**Source commit:** `251cd0aa6e80f92b43e8fb4da8b414fbc46ed795` | Component: `spiffe-helper-container`

---

### 8. ose-csi-node-driver-registrar-rhel9:latest

**Pull:**
```
$ podman pull registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9:latest
Trying to pull registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9:latest...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:e6ebf998a2970a683b872bdc2172d0a88262f549486775f43f3b499b867502a9
Copying blob sha256:4348899fa4910c81b110a0f2c4818daf666325f893b093cbd1e3c1691403f06c
Copying blob sha256:f28de10ddcf9540cbc5c81190f3840364bd0167cebd0991f5506d77d0d509081
Copying blob sha256:58b9f5212a4e4f19339c108e4b89a08eaced5b6521f5757f8fb657a2eae2b98d
Copying config sha256:3e6c64aec74387f09dcc3d6e993cfde51a6c140b9d9a62d6f7bcd67a1e6bca38
Writing manifest to image destination
Storing signatures
3e6c64aec74387f09dcc3d6e993cfde51a6c140b9d9a62d6f7bcd67a1e6bca38
```
**Digest:** `sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232`
**Source commit:** `d29f3f7a4aed4465e7e40e323bd3c0e0d9871e4c` | Component: `csi-node-driver-registrar-container` | Version: `v4.21.0`

> **Note:** Tag `v2.15.0` does not exist for this image. Used `latest` which resolves to `v4.21.0` (OCP version scheme).

---

### 9. ubi9:latest

**Pull:**
```
$ podman pull registry.access.redhat.com/ubi9:latest
Trying to pull registry.access.redhat.com/ubi9:latest...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:1d5cc9690f8e983825683dec7f7527629407c325fe8a87ca8ebe81776bfbd222
Copying config sha256:61a32414b891d69fb5b3d198b9f0b2c83827922a56a4678e40432a2a78f9823d
Writing manifest to image destination
Storing signatures
61a32414b891d69fb5b3d198b9f0b2c83827922a56a4678e40432a2a78f9823d
```
**Digest:** `sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319`
**Source commit:** `a1ff645e4d0b83aad1b77555a562c5807a8af5bf` | Component: `ubi9-container` | Version: `9.8`