### PR TITLE
SPIRE-418: Add v1.1.0 FBC catalog bundles and update channel entries

### DIFF
--- a/.tekton/fbc-build-pipeline.yaml
+++ b/.tekton/fbc-build-pipeline.yaml
@@ -96,7 +96,7 @@ spec:
             - name: name
               value: init
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:b797dd453ddad669365de6de4649e3a9e37e77aa26eb9862ca079a36cbfe64a4
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
             - name: kind
               value: task
           resolver: bundles
@@ -117,7 +117,7 @@ spec:
             - name: name
               value: git-clone-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
             - name: kind
               value: task
           resolver: bundles
@@ -145,7 +145,7 @@ spec:
             - name: name
               value: run-opm-command-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-run-opm-command-oci-ta:0.1@sha256:c79858b867713e44927438f6193c49004bf40bfd9248682f20c5a83ea2a9d2f1
+              value: quay.io/konflux-ci/tekton-catalog/task-run-opm-command-oci-ta:0.1@sha256:6a7c758802fd253735b15174c4e7ffffb6e271969adfddb3a083935986845166
             - name: kind
               value: task
           resolver: bundles
@@ -168,7 +168,7 @@ spec:
             - name: name
               value: prefetch-dependencies-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:1b209c0d93e52e418f3e6cd4b4fd915a84e4bd7f68e1cfd0d6446133540d7f43
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:0e6324edd0e6733a8c3400f46c4a638ed2f27063376f25a6f2b0220fca04ab77
             - name: kind
               value: task
           resolver: bundles
@@ -220,7 +220,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:9b6ee4a807cb471125ee7322c9d8b61e1ad1077e49acda7cca156d62f17ea8b7
             - name: kind
               value: task
           resolver: bundles
@@ -242,7 +242,7 @@ spec:
             - name: name
               value: build-image-index
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
             - name: kind
               value: task
           resolver: bundles
@@ -259,7 +259,7 @@ spec:
             - name: name
               value: deprecated-image-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:57d1f556982115311f603dd9a728c52a7a1d092f022e1db4560da01eca9e5d17
+              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
             - name: kind
               value: task
           resolver: bundles
@@ -298,7 +298,7 @@ spec:
             - name: name
               value: validate-fbc
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:291cbcce7d965831dd5027caad5f47ac4146b6fac0a51358f2ad64603a008436
+              value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:1775e829842cbabe3537a543544bc1c3a39de114f5657462f436c09194250b5a
             - name: kind
               value: task
           resolver: bundles
@@ -324,7 +324,7 @@ spec:
             - name: name
               value: fbc-target-index-pruning-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:a7696d92734be62700723b6d2c40dfaee4809e6a1d42b28deefc7c7463176c32
             - name: kind
               value: task
           resolver: bundles
@@ -348,7 +348,7 @@ spec:
             - name: name
               value: fbc-fips-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:247616a7e353ac77f2433989802cd3854c0b3b674386e160cae80c075a95f7db
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:e957d0399fb5579163f00967aea2c137cf25d0679592e4a480e8d850db18d4f0
             - name: kind
               value: task
           resolver: bundles

--- a/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,0 +1,365 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+name: zero-trust-workload-identity-manager.v1.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriver
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgent
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProvider
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServer
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 1.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpiffeCSIDriver",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "agentSocketPath": "/run/spire/agent-sockets",
+              "pluginName": "csi.spiffe.io"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireAgent",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "logFormat": "text",
+              "logLevel": "info",
+              "nodeAttestor": {
+                "k8sPSATEnabled": "true"
+              },
+              "workloadAttestors": {
+                "k8sEnabled": "true",
+                "workloadAttestorsVerification": {
+                  "type": "auto"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireOIDCDiscoveryProvider",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "csiDriverName": "csi.spiffe.io",
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "managedRoute": "true",
+              "replicaCount": 1
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireServer",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "caKeyType": "rsa-2048",
+              "caSubject": {
+                "commonName": "SPIRE Server CA",
+                "country": "US",
+                "organization": "Example Corp"
+              },
+              "caValidity": "24h",
+              "datastore": {
+                "connectionString": "/run/spire/data/datastore.sqlite3",
+                "databaseType": "sqlite3",
+                "maxIdleConns": 2,
+                "maxOpenConns": 100
+              },
+              "defaultJWTValidity": "5m",
+              "defaultX509Validity": "1h",
+              "federation": {
+                "bundleEndpoint": {
+                  "profile": "https_spiffe",
+                  "refreshHint": 300
+                },
+                "federatesWith": [
+                  {
+                    "bundleEndpointProfile": "https_spiffe",
+                    "bundleEndpointUrl": "https://federation.partner.example.com:8443",
+                    "endpointSpiffeId": "spiffe://partner.example.com/federation/endpoint",
+                    "trustDomain": "partner.example.com"
+                  }
+                ],
+                "managedRoute": "true"
+              },
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "persistence": {
+                "accessMode": "ReadWriteOnce",
+                "size": "2Gi",
+                "storageClass": ""
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "bundleConfigMap": "spire-bundle",
+              "clusterName": "prod-cluster",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterFederatedTrustDomain",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example.com"
+            },
+            "spec": {
+              "bundleEndpointProfile": "https_web",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterSPIFFEID",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-workload",
+              "namespace": "default"
+            },
+            "spec": {
+              "dnsNameTemplates": [
+                "*.example.com"
+              ],
+              "ttl": 3600,
+              "workloadSelector": {
+                "k8sServiceAccount": {
+                  "name": "example-sa",
+                  "namespace": "example-ns"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterStaticEntry",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-static-entry",
+              "namespace": "default"
+            },
+            "spec": {
+              "parentID": "spiffe://example.com/spire/server",
+              "selectors": [
+                {
+                  "type": "unix",
+                  "value": "uid:1000"
+                }
+              ],
+              "spiffeID": "spiffe://example.com/example-workload",
+              "ttl": 3600
+            }
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+      createdAt: 2026-06-05T15:12:12
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriver
+        name: spiffecsidrivers.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgent
+        name: spireagents.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProvider
+        name: spireoidcdiscoveryproviders.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServer
+        name: spireservers.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is an Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
+  name: spiffe-csi-init-container
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
+  name: node-driver-registrar
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
+  name: spiffe-csi-driver
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
+  name: spire-agent
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
+  name: spire-controller-manager
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
+  name: spire-oidc-discovery-provider
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
+  name: spire-server
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
+++ b/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
@@ -13,6 +13,9 @@ entries:
 - name: zero-trust-workload-identity-manager.v1.0.1
   replaces: zero-trust-workload-identity-manager.v1.0.0
   skipRange: '>=1.0.0 <1.0.1'
+- name: zero-trust-workload-identity-manager.v1.1.0
+  replaces: zero-trust-workload-identity-manager.v1.0.1
+  skipRange: '>=1.0.1 <1.1.0'
 name: stable-v1
 package: openshift-zero-trust-workload-identity-manager
 schema: olm.channel

--- a/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,0 +1,365 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+name: zero-trust-workload-identity-manager.v1.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriver
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgent
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProvider
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServer
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 1.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpiffeCSIDriver",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "agentSocketPath": "/run/spire/agent-sockets",
+              "pluginName": "csi.spiffe.io"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireAgent",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "logFormat": "text",
+              "logLevel": "info",
+              "nodeAttestor": {
+                "k8sPSATEnabled": "true"
+              },
+              "workloadAttestors": {
+                "k8sEnabled": "true",
+                "workloadAttestorsVerification": {
+                  "type": "auto"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireOIDCDiscoveryProvider",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "csiDriverName": "csi.spiffe.io",
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "managedRoute": "true",
+              "replicaCount": 1
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireServer",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "caKeyType": "rsa-2048",
+              "caSubject": {
+                "commonName": "SPIRE Server CA",
+                "country": "US",
+                "organization": "Example Corp"
+              },
+              "caValidity": "24h",
+              "datastore": {
+                "connectionString": "/run/spire/data/datastore.sqlite3",
+                "databaseType": "sqlite3",
+                "maxIdleConns": 2,
+                "maxOpenConns": 100
+              },
+              "defaultJWTValidity": "5m",
+              "defaultX509Validity": "1h",
+              "federation": {
+                "bundleEndpoint": {
+                  "profile": "https_spiffe",
+                  "refreshHint": 300
+                },
+                "federatesWith": [
+                  {
+                    "bundleEndpointProfile": "https_spiffe",
+                    "bundleEndpointUrl": "https://federation.partner.example.com:8443",
+                    "endpointSpiffeId": "spiffe://partner.example.com/federation/endpoint",
+                    "trustDomain": "partner.example.com"
+                  }
+                ],
+                "managedRoute": "true"
+              },
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "persistence": {
+                "accessMode": "ReadWriteOnce",
+                "size": "2Gi",
+                "storageClass": ""
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "bundleConfigMap": "spire-bundle",
+              "clusterName": "prod-cluster",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterFederatedTrustDomain",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example.com"
+            },
+            "spec": {
+              "bundleEndpointProfile": "https_web",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterSPIFFEID",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-workload",
+              "namespace": "default"
+            },
+            "spec": {
+              "dnsNameTemplates": [
+                "*.example.com"
+              ],
+              "ttl": 3600,
+              "workloadSelector": {
+                "k8sServiceAccount": {
+                  "name": "example-sa",
+                  "namespace": "example-ns"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterStaticEntry",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-static-entry",
+              "namespace": "default"
+            },
+            "spec": {
+              "parentID": "spiffe://example.com/spire/server",
+              "selectors": [
+                {
+                  "type": "unix",
+                  "value": "uid:1000"
+                }
+              ],
+              "spiffeID": "spiffe://example.com/example-workload",
+              "ttl": 3600
+            }
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+      createdAt: 2026-06-05T15:12:12
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriver
+        name: spiffecsidrivers.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgent
+        name: spireagents.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProvider
+        name: spireoidcdiscoveryproviders.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServer
+        name: spireservers.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is an Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
+  name: spiffe-csi-init-container
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
+  name: node-driver-registrar
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
+  name: spiffe-csi-driver
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
+  name: spire-agent
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
+  name: spire-controller-manager
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
+  name: spire-oidc-discovery-provider
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
+  name: spire-server
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
+++ b/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
@@ -21,6 +21,9 @@ entries:
 - name: zero-trust-workload-identity-manager.v1.0.1
   replaces: zero-trust-workload-identity-manager.v1.0.0
   skipRange: '>=1.0.0 <1.0.1'
+- name: zero-trust-workload-identity-manager.v1.1.0
+  replaces: zero-trust-workload-identity-manager.v1.0.1
+  skipRange: '>=1.0.1 <1.1.0'
 name: stable-v1
 package: openshift-zero-trust-workload-identity-manager
 schema: olm.channel

--- a/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,0 +1,365 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+name: zero-trust-workload-identity-manager.v1.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriver
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgent
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProvider
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServer
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 1.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpiffeCSIDriver",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "agentSocketPath": "/run/spire/agent-sockets",
+              "pluginName": "csi.spiffe.io"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireAgent",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "logFormat": "text",
+              "logLevel": "info",
+              "nodeAttestor": {
+                "k8sPSATEnabled": "true"
+              },
+              "workloadAttestors": {
+                "k8sEnabled": "true",
+                "workloadAttestorsVerification": {
+                  "type": "auto"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireOIDCDiscoveryProvider",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "csiDriverName": "csi.spiffe.io",
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "managedRoute": "true",
+              "replicaCount": 1
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireServer",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "caKeyType": "rsa-2048",
+              "caSubject": {
+                "commonName": "SPIRE Server CA",
+                "country": "US",
+                "organization": "Example Corp"
+              },
+              "caValidity": "24h",
+              "datastore": {
+                "connectionString": "/run/spire/data/datastore.sqlite3",
+                "databaseType": "sqlite3",
+                "maxIdleConns": 2,
+                "maxOpenConns": 100
+              },
+              "defaultJWTValidity": "5m",
+              "defaultX509Validity": "1h",
+              "federation": {
+                "bundleEndpoint": {
+                  "profile": "https_spiffe",
+                  "refreshHint": 300
+                },
+                "federatesWith": [
+                  {
+                    "bundleEndpointProfile": "https_spiffe",
+                    "bundleEndpointUrl": "https://federation.partner.example.com:8443",
+                    "endpointSpiffeId": "spiffe://partner.example.com/federation/endpoint",
+                    "trustDomain": "partner.example.com"
+                  }
+                ],
+                "managedRoute": "true"
+              },
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "persistence": {
+                "accessMode": "ReadWriteOnce",
+                "size": "2Gi",
+                "storageClass": ""
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "bundleConfigMap": "spire-bundle",
+              "clusterName": "prod-cluster",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterFederatedTrustDomain",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example.com"
+            },
+            "spec": {
+              "bundleEndpointProfile": "https_web",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterSPIFFEID",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-workload",
+              "namespace": "default"
+            },
+            "spec": {
+              "dnsNameTemplates": [
+                "*.example.com"
+              ],
+              "ttl": 3600,
+              "workloadSelector": {
+                "k8sServiceAccount": {
+                  "name": "example-sa",
+                  "namespace": "example-ns"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterStaticEntry",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-static-entry",
+              "namespace": "default"
+            },
+            "spec": {
+              "parentID": "spiffe://example.com/spire/server",
+              "selectors": [
+                {
+                  "type": "unix",
+                  "value": "uid:1000"
+                }
+              ],
+              "spiffeID": "spiffe://example.com/example-workload",
+              "ttl": 3600
+            }
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+      createdAt: 2026-06-05T15:12:12
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriver
+        name: spiffecsidrivers.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgent
+        name: spireagents.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProvider
+        name: spireoidcdiscoveryproviders.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServer
+        name: spireservers.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is an Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
+  name: spiffe-csi-init-container
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
+  name: node-driver-registrar
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
+  name: spiffe-csi-driver
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
+  name: spire-agent
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
+  name: spire-controller-manager
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
+  name: spire-oidc-discovery-provider
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
+  name: spire-server
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
+++ b/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
@@ -5,6 +5,9 @@ entries:
 - name: zero-trust-workload-identity-manager.v1.0.1
   replaces: zero-trust-workload-identity-manager.v1.0.0
   skipRange: '>=1.0.0 <1.0.1'
+- name: zero-trust-workload-identity-manager.v1.1.0
+  replaces: zero-trust-workload-identity-manager.v1.0.1
+  skipRange: '>=1.0.1 <1.1.0'
 name: stable-v1
 package: openshift-zero-trust-workload-identity-manager
 schema: olm.channel

--- a/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,0 +1,365 @@
+---
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+name: zero-trust-workload-identity-manager.v1.1.0
+package: openshift-zero-trust-workload-identity-manager
+properties:
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpiffeCSIDriver
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireAgent
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireOIDCDiscoveryProvider
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: SpireServer
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.openshift.io
+    kind: ZeroTrustWorkloadIdentityManager
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterFederatedTrustDomain
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterSPIFFEID
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: spire.spiffe.io
+    kind: ClusterStaticEntry
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-zero-trust-workload-identity-manager
+    version: 1.1.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpiffeCSIDriver",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "agentSocketPath": "/run/spire/agent-sockets",
+              "pluginName": "csi.spiffe.io"
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireAgent",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "logFormat": "text",
+              "logLevel": "info",
+              "nodeAttestor": {
+                "k8sPSATEnabled": "true"
+              },
+              "workloadAttestors": {
+                "k8sEnabled": "true",
+                "workloadAttestorsVerification": {
+                  "type": "auto"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireOIDCDiscoveryProvider",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "csiDriverName": "csi.spiffe.io",
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "managedRoute": "true",
+              "replicaCount": 1
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "SpireServer",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "caKeyType": "rsa-2048",
+              "caSubject": {
+                "commonName": "SPIRE Server CA",
+                "country": "US",
+                "organization": "Example Corp"
+              },
+              "caValidity": "24h",
+              "datastore": {
+                "connectionString": "/run/spire/data/datastore.sqlite3",
+                "databaseType": "sqlite3",
+                "maxIdleConns": 2,
+                "maxOpenConns": 100
+              },
+              "defaultJWTValidity": "5m",
+              "defaultX509Validity": "1h",
+              "federation": {
+                "bundleEndpoint": {
+                  "profile": "https_spiffe",
+                  "refreshHint": 300
+                },
+                "federatesWith": [
+                  {
+                    "bundleEndpointProfile": "https_spiffe",
+                    "bundleEndpointUrl": "https://federation.partner.example.com:8443",
+                    "endpointSpiffeId": "spiffe://partner.example.com/federation/endpoint",
+                    "trustDomain": "partner.example.com"
+                  }
+                ],
+                "managedRoute": "true"
+              },
+              "jwtIssuer": "https://oidc-discovery.example.com",
+              "logFormat": "text",
+              "logLevel": "info",
+              "persistence": {
+                "accessMode": "ReadWriteOnce",
+                "size": "2Gi",
+                "storageClass": ""
+              }
+            }
+          },
+          {
+            "apiVersion": "operator.openshift.io/v1alpha1",
+            "kind": "ZeroTrustWorkloadIdentityManager",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "cluster"
+            },
+            "spec": {
+              "bundleConfigMap": "spire-bundle",
+              "clusterName": "prod-cluster",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterFederatedTrustDomain",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example.com"
+            },
+            "spec": {
+              "bundleEndpointProfile": "https_web",
+              "trustDomain": "example.com"
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterSPIFFEID",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-workload",
+              "namespace": "default"
+            },
+            "spec": {
+              "dnsNameTemplates": [
+                "*.example.com"
+              ],
+              "ttl": 3600,
+              "workloadSelector": {
+                "k8sServiceAccount": {
+                  "name": "example-sa",
+                  "namespace": "example-ns"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "spire.spiffe.io/v1alpha1",
+            "kind": "ClusterStaticEntry",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/managed-by": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/name": "zero-trust-workload-identity-manager",
+                "app.kubernetes.io/part-of": "zero-trust-workload-identity-manager"
+              },
+              "name": "example-static-entry",
+              "namespace": "default"
+            },
+            "spec": {
+              "parentID": "spiffe://example.com/spire/server",
+              "selectors": [
+                {
+                  "type": "unix",
+                  "value": "uid:1000"
+                }
+              ],
+              "spiffeID": "spiffe://example.com/example-workload",
+              "ttl": 3600
+            }
+          }
+        ]
+      capabilities: Basic Install
+      console.openshift.io/disable-operand-delete: "true"
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+      createdAt: 2026-06-05T15:12:12
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
+      operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.39.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/openshift/zero-trust-workload-identity-manager
+      support: Red Hat, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: ClusterFederatedTrustDomain
+        name: clusterfederatedtrustdomains.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterSPIFFEID
+        name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+      - kind: ClusterStaticEntry
+        name: clusterstaticentries.spire.spiffe.io
+        version: v1alpha1
+      - kind: SpiffeCSIDriver
+        name: spiffecsidrivers.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireAgent
+        name: spireagents.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireOIDCDiscoveryProvider
+        name: spireoidcdiscoveryproviders.operator.openshift.io
+        version: v1alpha1
+      - kind: SpireServer
+        name: spireservers.operator.openshift.io
+        version: v1alpha1
+      - kind: ZeroTrustWorkloadIdentityManager
+        name: zerotrustworkloadidentitymanagers.operator.openshift.io
+        version: v1alpha1
+    description: The Zero Trust Workload Identity Manager is an Openshift Day-2 Operator
+      designed to automate the setup and management of SPIFFE/SPIRE components (like
+      spire-server, spire-agent, spiffe-csi-driver, and oidc-discovery-provider) within
+      OpenShift clusters. It enables zero-trust security by dynamically issuing and
+      rotating workload identities, enforcing strict identity-based authentication
+      across workloads. This manager abstracts complex SPIRE configurations, streamlining
+      workload onboarding with secure identities and improving the cluster's overall
+      security posture.
+    displayName: Zero Trust Workload Identity Manager
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zero-trust-workload-identity-manager
+    - ztwim
+    - spire
+    - spiffe-spire
+    - security
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Documentation
+      url: https://github.com/openshift/zero-trust-workload-identity-manager/blob/master/README.md
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
+  name: spiffe-csi-init-container
+- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
+  name: node-driver-registrar
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
+  name: spiffe-csi-driver
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
+  name: spire-agent
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
+  name: spire-controller-manager
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
+  name: spire-oidc-discovery-provider
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
+  name: spire-server
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
+  name: ""
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
+  name: ""
+schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
+++ b/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/channel.yaml
@@ -5,6 +5,9 @@ entries:
 - name: zero-trust-workload-identity-manager.v1.0.1
   replaces: zero-trust-workload-identity-manager.v1.0.0
   skipRange: '>=1.0.0 <1.0.1'
+- name: zero-trust-workload-identity-manager.v1.1.0
+  replaces: zero-trust-workload-identity-manager.v1.0.1
+  skipRange: '>=1.0.1 <1.1.0'
 name: stable-v1
 package: openshift-zero-trust-workload-identity-manager
 schema: olm.channel


### PR DESCRIPTION
## Summary
- Add `bundle-v1.1.0.yaml` to all four OCP catalogs (v4.18, v4.19, v4.20, v4.21)
- Update `stable-v1` channel in each catalog to include v1.1.0 (replaces v1.0.1)
- Bundle independently rendered for each catalog version from stage operator bundle image using `opm render`

## Changes Per Catalog

| Catalog | Files Changed |
|---------|--------------|
| v4.18 | `bundle-v1.1.0.yaml` (new), `channel.yaml` (updated) |
| v4.19 | `bundle-v1.1.0.yaml` (new), `channel.yaml` (updated) |
| v4.20 | `bundle-v1.1.0.yaml` (new), `channel.yaml` (updated) |
| v4.21 | `bundle-v1.1.0.yaml` (new), `channel.yaml` (updated) |

## Channel Update (stable-v1)

New entry added to each `channel.yaml`:
```yaml
- name: zero-trust-workload-identity-manager.v1.1.0
  replaces: zero-trust-workload-identity-manager.v1.0.1
  skipRange: '>=1.0.1 <1.1.0'
```

---

## Detailed Command Proof

### Step 1: Pull the v1.1.0 operator bundle image from stage registry

```
$ podman pull registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle:v1.1.0

Trying to pull registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle:v1.1.0...
Getting image source signatures
Copying blob sha256:d434b923cd152254f58ed181bf66ca178651aa59250df1d95343a1669c0facbe
Copying blob sha256:dd148063a98f38d63a03cea2357d237d418889b91f204f507c033c944e443f45
Copying config sha256:11f4270fe68350acd53beb18c2c3724f380c4e0b8374a606b580d245d2b262a4
Writing manifest to image destination
11f4270fe68350acd53beb18c2c3724f380c4e0b8374a606b580d245d2b262a4
```

### Step 2: Get SHA digest of the bundle image

```
$ podman inspect --format '{{.Digest}}' registry.stage.redhat.io/...operator-bundle:v1.1.0

sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
```

---

### Step 3: Render bundle independently for each OCP catalog version

#### v4.18

```
$ ./bin/tools/opm render \
  "registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892" \
  --migrate-level=bundle-object-to-csv-metadata -o yaml \
  > catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml

Result: SUCCESS - 365 lines
md5: d7a6479b0ba232f082ada11b54a27721
```

**Image references in v4.18 bundle:**
```
image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
- image: registry.stage.redhat.io/.../spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
- image: registry.stage.redhat.io/.../spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
- image: registry.stage.redhat.io/.../spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
- image: registry.stage.redhat.io/.../spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
- image: registry.stage.redhat.io/.../spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
```

#### v4.19

```
$ ./bin/tools/opm render \
  "registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892" \
  --migrate-level=bundle-object-to-csv-metadata -o yaml \
  > catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml

Result: SUCCESS - 365 lines
md5: d7a6479b0ba232f082ada11b54a27721
```

**Image references in v4.19 bundle:**
```
image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
- image: registry.stage.redhat.io/.../spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
- image: registry.stage.redhat.io/.../spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
- image: registry.stage.redhat.io/.../spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
- image: registry.stage.redhat.io/.../spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
- image: registry.stage.redhat.io/.../spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
```

#### v4.20

```
$ ./bin/tools/opm render \
  "registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892" \
  --migrate-level=bundle-object-to-csv-metadata -o yaml \
  > catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml

Result: SUCCESS - 365 lines
md5: d7a6479b0ba232f082ada11b54a27721
```

**Image references in v4.20 bundle:**
```
image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
- image: registry.stage.redhat.io/.../spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
- image: registry.stage.redhat.io/.../spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
- image: registry.stage.redhat.io/.../spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
- image: registry.stage.redhat.io/.../spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
- image: registry.stage.redhat.io/.../spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
```

#### v4.21

```
$ ./bin/tools/opm render \
  "registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892" \
  --migrate-level=bundle-object-to-csv-metadata -o yaml \
  > catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml

Result: SUCCESS - 365 lines
md5: d7a6479b0ba232f082ada11b54a27721
```

**Image references in v4.21 bundle:**
```
image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319
- image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232
- image: registry.stage.redhat.io/.../spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703
- image: registry.stage.redhat.io/.../spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8
- image: registry.stage.redhat.io/.../spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea
- image: registry.stage.redhat.io/.../spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7
- image: registry.stage.redhat.io/.../spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-operator-bundle@sha256:b966d0bc88037bba90443d05138a462cdd106edcb9da162355220e8ed8f2b892
- image: registry.stage.redhat.io/.../zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711
```

> **Cross-verification:** All four catalogs rendered independently produce identical output (md5: `d7a6479b0ba232f082ada11b54a27721`, 365 lines each).

---

### Step 4: Validate all catalogs with opm

```
$ ./bin/tools/opm validate catalogs/v4.18/catalog
PASSED

$ ./bin/tools/opm validate catalogs/v4.19/catalog
PASSED

$ ./bin/tools/opm validate catalogs/v4.20/catalog
PASSED

$ ./bin/tools/opm validate catalogs/v4.21/catalog
PASSED
```

All four catalogs passed OPM validation successfully.