### PR TITLE
NO-JIRA: Update operator stage image digest for v1.1.0

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:c0d3483dd5b0a413c486dabfa86dd25dd199b7a0877b072be5756f9f95e6c711"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de"
 SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8"
 SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8"
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703"


### PR DESCRIPTION
## Summary

Update the `zero-trust-workload-identity-manager-rhel9` operator image digest in `images_digest.conf` to the latest stage build that includes the submodule update from PR #204.

## SHA Verification

| Component | Old Digest | New Digest |
|-----------|-----------|-----------|
| zero-trust-workload-identity-manager-rhel9 | `sha256:c0d3483...` | `sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de` |

**Verified commit**: `19fd2b9e910b5c910990dc6d4898e9446a3854f1` (merge of PR #204)

All other component image digests remain unchanged as they were not affected by the submodule update.

Made with [Cursor](https://cursor.com)