### PR TITLE
SPIRE-418: Update operator stage image digest for v1.1.0

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,7 +4,7 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78"
 SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8"
 SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8"
 SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703"


### PR DESCRIPTION
## Summary

Update the `zero-trust-workload-identity-manager-rhel9` operator image digest in `images_digest.conf` to the latest stage build that includes the submodule update and Tekton task bundle fixes from PR #209.

## Image Verification

```
$ skopeo inspect docker://registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9:v1.1.0-1781684732

Digest:  sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
Version: v1.1.0
Commit:  612309a974bd1088aef290ed71b150837136a701
```

**Commit `612309a`** = Merge of PR #209 into `release-1.1`, which includes:
- Operator submodule update to d4b265f2 (openshift/zero-trust-workload-identity-manager#140, #141)
- Tekton task bundle SHA fixes for EC compliance

## Digest Change

| | Old | New |
|--|-----|-----|
| SHA | `sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de` | `sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78` |
| Built from | PR #206 merge (`93439ff`) | PR #209 merge (`612309a`) |
| Tag | `v1.1.0-1780989796` | `v1.1.0-1781684732` |

## Note

All other component image digests remain unchanged as they were not affected by PR #209.

Made with [Cursor](https://cursor.com)