### PR TITLE
SPIRE-418: Update v1.1.0 FBC catalog bundles to latest stage image

### DIFF
--- a/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.18/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
 name: zero-trust-workload-identity-manager.v1.1.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -258,8 +258,8 @@ properties:
         ]
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
-      createdAt: 2026-06-09T08:16:27
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
+      createdAt: 2026-06-17T09:09:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -359,8 +359,8 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
   name: ""
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.19/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
 name: zero-trust-workload-identity-manager.v1.1.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -258,8 +258,8 @@ properties:
         ]
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
-      createdAt: 2026-06-09T08:16:27
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
+      createdAt: 2026-06-17T09:09:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -359,8 +359,8 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
   name: ""
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.20/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
 name: zero-trust-workload-identity-manager.v1.1.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -258,8 +258,8 @@ properties:
         ]
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
-      createdAt: 2026-06-09T08:16:27
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
+      createdAt: 2026-06-17T09:09:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -359,8 +359,8 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
   name: ""
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
+++ b/catalogs/v4.21/catalog/openshift-zero-trust-workload-identity-manager/bundle-v1.1.0.yaml
@@ -1,5 +1,5 @@
 ---
-image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
 name: zero-trust-workload-identity-manager.v1.1.0
 package: openshift-zero-trust-workload-identity-manager
 properties:
@@ -258,8 +258,8 @@ properties:
         ]
       capabilities: Basic Install
       console.openshift.io/disable-operand-delete: "true"
-      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
-      createdAt: 2026-06-09T08:16:27
+      containerImage: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
+      createdAt: 2026-06-17T09:09:26
       features.operators.openshift.io/cnf: "false"
       features.operators.openshift.io/cni: "false"
       features.operators.openshift.io/csi: "true"
@@ -359,8 +359,8 @@ relatedImages:
   name: spire-oidc-discovery-provider
 - image: registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8
   name: spire-server
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle@sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
   name: ""
-- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:305bb1c21caedddfdd053327801450c3391e6c81762934702e18ec8028f273de
+- image: registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
   name: ""
 schema: olm.bundle


### PR DESCRIPTION
## Summary

Update `bundle-v1.1.0.yaml` in all FBC catalog versions (v4.18, v4.19, v4.20, v4.21) to use the latest operator bundle image from the stage registry.

## Bundle Image Verification

```
$ skopeo inspect docker://registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle:v1.1.0-1781687342

Digest:  sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787
Version: v1.1.0
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
```

**Commit `c73ed72`** = Merge of PR #211 into `release-1.1`, which includes:
- Updated operator image digest (from PR #209 merge build)
- Tekton task bundle SHA fixes for EC compliance
- Operator submodule update with status condition and readability improvements

## Digest Change

| | Old | New |
|--|-----|-----|
| Bundle SHA | `sha256:3d173a6c247f406bbd02c374985bf1969ddeeb7304ea567ae025a01ce20fb0d0` | `sha256:2fe3940ebd233d706d23b265263e634e2a96580088dab6e4afffa1bf270eb787` |
| Built from | PR #206 merge (`93439ff`) | PR #211 merge (`c73ed72`) |
| Tag | `v1.1.0-1780992963` | `v1.1.0-1781687342` |

Made with [Cursor](https://cursor.com)