### PR TITLE
SPIRE-414: Update images_digest.conf to production registry with latest digests

### DIFF
--- a/images_digest.conf
+++ b/images_digest.conf
@@ -4,12 +4,12 @@
 # This is currently sourced in `hack/bundle/render_templates.sh` to update the image references in the operator CSV.
 
 
-ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78"
-SPIRE_SERVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:7d71c6931bd5502714d3f965487efb28c22ff53cf4ba6027c90b495cb40f75c8"
-SPIRE_AGENT_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:356f7502bb5d5c6e98a3317152c5daba09ae2a8d3e3bde7bc7e319ead367a6c8"
-SPIFFE_CSI_DRIVER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:d69ea9f935be90c3e8e1fe5b0d75bfbefa1ffd9ceb729cc73e9a2b17eaa21703"
-SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3655f46744e650aceefe9566aca21197cc40a6f6d974e6b6574a395ee01457c7"
-SPIRE_CONTROLLER_MANAGER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:b74141ffbdcac98fa12b1cd4ae0b3309d9bd06814e3d9d38c7afab0019bbb7ea"
-SPIFFE_HELPER_IMAGE="registry.stage.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9@sha256:977148a3e7cfdc64fa98435398cb6dbbfc346c6c2b21f416b8953519e0e92ac4"
+ZERO_TRUST_WORKLOAD_IDENTITY_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9@sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78"
+SPIRE_SERVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9@sha256:dad8fc67061ccbf88920d16c3ff909ae5a8e44c7c935a76d6e38e4e7c6937aed"
+SPIRE_AGENT_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9@sha256:0aef06a46a4c03c6a040888a4e37b295fdbaf6fb5be8f9659d372255e379967d"
+SPIFFE_CSI_DRIVER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9@sha256:bd7cdc6d529f4b4861ebc97cb3d90edff02a1ac2c140f13e76f43c8f3f701828"
+SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9@sha256:3e2ab122b73886dbd007412d4ebfda860713d0a52171664cc34f56a4dc30194a"
+SPIRE_CONTROLLER_MANAGER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9@sha256:f4419b03084312a7b3c6e82ae0d260e570bf128041964fee7e109fa16222ab1d"
+SPIFFE_HELPER_IMAGE="registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9@sha256:41a3bbcb972300030cb6d3096c025a85b933266b6fe3c03f20be458069ebe4bb"
 NODE_DRIVER_REGISTRAR_IMAGE="registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:cdef553ad9d575832bb90464dc0297b0c681a929a0da537ca2393e070ccd3232"
 SPIFFE_CSI_INIT_CONTAINER_IMAGE="registry.access.redhat.com/ubi9@sha256:a7241cdcd984bccd84b0b5b18ef8643462ef8ca2a491ae5982dac11e1b497319"


### PR DESCRIPTION
## Summary

- Updates `images_digest.conf` to use production registry (`registry.redhat.io`) instead of staging (`registry.stage.redhat.io`)
- Pulls fresh SHA digests from the production registry for all 7 component images
- All operand images were built on 2026-06-23 from commit c73ed72 (PR #211 merge)
- Operator image built on 2026-06-17 from commit 612309a (PR #209 merge)

## Image Verification

### Operator

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9:v1.1.0

Digest:  sha256:ca4fe806712a0a5761544b8044d02b189eebe56c3a532a1d8423a53a39ed5c78
Version: v1.1.0
Commit:  612309a974bd1088aef290ed71b150837136a701
Built:   2026-06-17
```

**Commit `612309a`** = Merge of PR #209 into `release-1.1` (operator submodule update + Tekton task bundle fixes)

### SPIRE Server

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-server-rhel9:v1.14.7

Digest:  sha256:dad8fc67061ccbf88920d16c3ff909ae5a8e44c7c935a76d6e38e4e7c6937aed
Version: v1.14.7
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

### SPIRE Agent

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9:v1.14.7

Digest:  sha256:0aef06a46a4c03c6a040888a4e37b295fdbaf6fb5be8f9659d372255e379967d
Version: v1.14.7
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

### SPIFFE CSI Driver

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9:v0.2.8

Digest:  sha256:bd7cdc6d529f4b4861ebc97cb3d90edff02a1ac2c140f13e76f43c8f3f701828
Version: v0.2.8
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

### SPIRE OIDC Discovery Provider

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9:v1.14.7

Digest:  sha256:3e2ab122b73886dbd007412d4ebfda860713d0a52171664cc34f56a4dc30194a
Version: v1.14.7
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

### SPIRE Controller Manager

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9:v0.6.4

Digest:  sha256:f4419b03084312a7b3c6e82ae0d260e570bf128041964fee7e109fa16222ab1d
Version: v0.6.4
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

### SPIFFE Helper

```
$ skopeo inspect docker://registry.redhat.io/zero-trust-workload-identity-manager/spiffe-helper-rhel9:v0.11.0

Digest:  sha256:41a3bbcb972300030cb6d3096c025a85b933266b6fe3c03f20be458069ebe4bb
Version: v0.11.0
Commit:  c73ed720cd1ec77d4c1a9e2a4a9a9f15007b7839
Built:   2026-06-23
```

## Image Versions

| Component | Version | Build Date | Commit |
| --- | --- | --- | --- |
| zero-trust-workload-identity-manager | v1.1.0 | 2026-06-17 | 612309a (PR #209 merge) |
| spire-server | v1.14.7 | 2026-06-23 | c73ed72 (PR #211 merge) |
| spire-agent | v1.14.7 | 2026-06-23 | c73ed72 (PR #211 merge) |
| spiffe-csi-driver | v0.2.8 | 2026-06-23 | c73ed72 (PR #211 merge) |
| spire-oidc-discovery-provider | v1.14.7 | 2026-06-23 | c73ed72 (PR #211 merge) |
| spire-controller-manager | v0.6.4 | 2026-06-23 | c73ed72 (PR #211 merge) |
| spiffe-helper | v0.11.0 | 2026-06-23 | c73ed72 (PR #211 merge) |

## Files Changed

- `images_digest.conf` — registry and digest updates for 7 component images

Made with [Cursor](https://cursor.com)